### PR TITLE
make request sleep 1 second to prevent Webflow rate API limit

### DIFF
--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -58,7 +58,9 @@ class Api
         curl_setopt_array($curl, $options);
         $response = curl_exec($curl);
         curl_close($curl);
-        
+
+	sleep(1); // Because of rate API limit
+
         list($headers, $body) = explode("\r\n\r\n", $response, 2);
 
         while (strpos($body, "\r\n\r\n") !== false) {

--- a/src/Webflow/Api.php
+++ b/src/Webflow/Api.php
@@ -17,10 +17,12 @@ class Api
     private $finish;
 
     private $cache = [];
+    private $delay = 0;
 
     public function __construct(
         $token,
-        $version = '1.0.0'
+        $version = '1.0.0',
+        $delay = 0
     ) {
         if (empty($token)) {
             throw new WebflowException('token');
@@ -28,9 +30,22 @@ class Api
 
         $this->token = $token;
         $this->version = $version;
+        $this->delay = $delay;
 
         $this->rateRemaining = 60;
 
+        return $this;
+    }
+	
+    public function getDelay(): int
+    {
+	    return $this->delay;
+    }
+	
+    public function setDelay(int $delay): self
+    {
+	$this->delay = $delay;
+	    
         return $this;
     }
 
@@ -59,7 +74,9 @@ class Api
         $response = curl_exec($curl);
         curl_close($curl);
 
-	sleep(1); // Because of rate API limit
+	if ($this->delay > 0) {
+	    sleep($this->delay); // Because of rate API limit
+	}
 
         list($headers, $body) = explode("\r\n\r\n", $response, 2);
 


### PR DESCRIPTION
Add sleep call in the API request function.
Prevent Webflow to hit the rate API limit (which is 60 hits per minute)